### PR TITLE
Update unity-test.yml

### DIFF
--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -12,11 +12,11 @@ jobs:
   build:
       name: Run the Unity Test
       runs-on: ubuntu-latest
-      if: github.event.label.name == 'request-ci'
+      if: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'request-ci' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
       steps:
         - uses: actions/checkout@v4
           with:
-            ref: ${{ github.event.pull_request.head.sha }}
+            ref: ${{ github.event.pull_request.head.sha || github.sha }}
         - name: Set outputs
           id: vars
           run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/unity-test.yml` to expand the conditions under which the Unity Test job runs and improve flexibility in determining the commit reference.

### Workflow updates:

* Modified the `if` condition in the `build` job to allow the workflow to run for additional event types, including `push` and `workflow_dispatch`, alongside `pull_request_target` with the `request-ci` label. This change broadens the scenarios under which the workflow is triggered.
* Updated the `ref` parameter in the `actions/checkout` step to use the current commit SHA (`github.sha`) as a fallback if `pull_request.head.sha` is unavailable. This ensures compatibility across different event types.