### PR TITLE
Potential fix for code scanning alert no. 3 and 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unity-meta-file-check.yml
+++ b/.github/workflows/unity-meta-file-check.yml
@@ -12,6 +12,9 @@ on:
       - Packages/**
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   meta-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -13,6 +13,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   build:
       name: Run the Unity Test


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/DebugToolkit/security/code-scanning/4](https://github.com/AndanteTribe/DebugToolkit/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix: define it at the workflow root (applies to all jobs unless overridden) with `contents: read`, which is the minimal recommended baseline and sufficient for checkout/testing/artifact upload in this file.

Change location:
- File: `.github/workflows/unity-test.yml`
- Insert `permissions:` between the `on:` section and `jobs:` section.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
